### PR TITLE
Enabling testing and removing placeholder test

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,9 @@
+AllCops:
+  Exclude:
+    - 'Gemfile'
+    - 'Rakefile'
+    - 'beaker-i18n_helper.gemspec'
+
+Metrics/MethodLength:
+   Max: 200
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
-sudo: false
 language: ruby
-rvm:
-  - 2.4.0
-before_install: gem install bundler -v 1.15.3
+matrix:
+  fast_finish: true
+  include:
+    - rvm: 2.4.1
+    - rvm: 2.4.1
+      script: bundle exec rubocop
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,14 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in beaker-i18n_helper.gemspec
 gemspec
 
+group :test do
+  gem 'rubocop'
+  gem 'rake', '~> 10.0'
+  gem 'rspec', '~> 3.0'
+  gem 'beaker', '>= 3.0.0'
+  gem 'json'
+end
+
 group :development do
   # TODO: Use gem instead of git. Section mapping is merged into master, but not yet released
   gem 'github_changelog_generator', git: 'https://github.com/skywinder/github-changelog-generator.git', ref: '33f89614d47a4bca1a3ae02bdcc37edd0b012e86'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+build: off
+
+branches:
+  only:
+    - master
+
+# ruby versions under test
+environment:
+  matrix:
+    - RUBY_VERSION: 24-x64
+
+install:
+  - SET PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - SET LOG_SPEC_ORDER=true
+  - bundle install --jobs 4 --retry 2 --without development
+
+before_test:
+  - type Gemfile.lock
+  - ruby -v
+  - gem -v
+  - bundle -v
+
+test_script:
+  - bundle exec rake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,17 @@ install:
   - SET PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
   - SET LOG_SPEC_ORDER=true
   - bundle install --jobs 4 --retry 2 --without development
+  # Due to a bug in the version of OpenSSL shipped with Ruby 2.4.1 on Windows
+  # (https://bugs.ruby-lang.org/issues/11033). Errors are ignored because the
+  # mingw gem calls out to pacman to install OpenSSL which is already
+  # installed, causing gem to raise a warning that powershell determines to be
+  # a fatal error.
+  - ps: |
+      $ErrorActionPreference = "SilentlyContinue"
+      if($env:RUBY_VERSION -eq "24-x64") {
+        gem install openssl "~> 2.0.4" --no-rdoc --no-ri -- --with-openssl-dir=C:\msys64\mingw64
+      }
+      $host.SetShouldExit(0)
 
 before_test:
   - type Gemfile.lock

--- a/beaker-i18n_helper.gemspec
+++ b/beaker-i18n_helper.gemspec
@@ -28,9 +28,4 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.15"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-
-  spec.add_runtime_dependency "beaker", ">= 3.0.0"
 end

--- a/lib/beaker/i18n_helper.rb
+++ b/lib/beaker/i18n_helper.rb
@@ -1,24 +1,22 @@
 require 'beaker'
 
-module Beaker::I18nHelper
+# Setting up the module
+module Beaker::I18nHelper # rubocop:disable Style/ClassAndModuleChildren
   include Beaker::DSL
   include Beaker::DSL::Helpers::FacterHelpers
 
   def install_language_pack(hsts, lang)
+    lang = lang.split('.')[0] if lang =~ /\.\w$/
 
-    if lang.match(/\.\w$/)
-      lang = lang.split(".")[0]
-    end
-
-    if lang.match(/_/)
-      lang = lang.split("_")
-    elsif lang.match(/-/)
-      lang = lang.split("-")
+    if lang =~ /_/
+      lang = lang.split('_')
+    elsif lang =~ /-/
+      lang = lang.split('-')
     end
 
     Array(hsts).each do |host|
-      if fact_on(host, "osfamily") == 'Debian'
-        install_package(host, "systemd-services")
+      if fact_on(host, 'osfamily') == 'Debian'
+        install_package(host, 'systemd-services')
         install_package(host, "language-pack-#{lang[0]}")
       end
     end

--- a/lib/beaker/i18n_helper/version.rb
+++ b/lib/beaker/i18n_helper/version.rb
@@ -1,5 +1,5 @@
 module Beaker
   module I18nHelper
-    VERSION = "0.2.0"
+    VERSION = '0.2.0'.freeze
   end
 end

--- a/spec/beaker/i18n_helper_spec.rb
+++ b/spec/beaker/i18n_helper_spec.rb
@@ -1,7 +1,7 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe Beaker::I18nHelper do
-  it "has a version number" do
+  it 'has a version number' do
     expect(Beaker::I18nHelper::VERSION).not_to be nil
   end
 end

--- a/spec/beaker/i18n_helper_spec.rb
+++ b/spec/beaker/i18n_helper_spec.rb
@@ -4,8 +4,4 @@ RSpec.describe Beaker::I18nHelper do
   it "has a version number" do
     expect(Beaker::I18nHelper::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,9 @@
-require "bundler/setup"
-require "beaker/i18n_helper"
+require 'bundler/setup'
+require 'beaker/i18n_helper'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
This PR enables Rubocop on Travis and spec tests on Appveyor. 
It also removes a placeholder than that was initially implemented to fail.


Still need to add Rubocop and address failures.