### PR TITLE
(FM-6405) add unit and acceptance tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,5 +5,9 @@ AllCops:
     - 'beaker-i18n_helper.gemspec'
 
 Metrics/MethodLength:
-   Max: 200
-
+  Max: 200
+Metrics/LineLength:
+  Max: 105
+Style/RegexpLiteral:
+  Description: Community preference. See https://github.com/voxpupuli/modulesync_config/issues/168
+  EnforcedStyle: percent_r

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,13 @@ matrix:
   fast_finish: true
   include:
     - rvm: 2.4.1
+      script: bundle exec rspec spec/beaker
     - rvm: 2.4.1
       script: bundle exec rubocop
+    - rvm: 2.4.1
+      env: BEAKER_provision=yes BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04
+      script: bundle exec rspec spec/acceptance
+      services: docker
+      sudo: required
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :test do
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 3.0'
   gem 'beaker', '>= 3.0.0'
+  gem 'beaker-rspec'
 end
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ c.before :suite do
       end
     end
     #set language
-    change_locale_on(host, "ja_JP")
+    change_locale_on(host, "ja_JP.utf-8")
     on host, puppet('module', 'install', 'stahnma/epel')
   end
 end
@@ -59,21 +59,37 @@ Usually only needed for Debian systems, RHEL installs all language packs by defa
 
 #### change_locale_on(host, lang)
 
-Changes the system local on a given unix host or hosts. Takes in a language string also and sets LANG and LANGUAGE on the target host to `#{lang}.utf8`.
+Takes in a string, `lang`, and sets $LANG, $LANGUAGE, and $LC_ALL on the target host to `#{lang}`. We **strongly** recommend appending ".utf-8" to your `lang` string.
 
 e.g.
 
 ```ruby
-change_locale_on(host, "en_GB")
+change_locale_on(host, "en_GB.utf-8")
 ```
 
 ## Limitations
 
 So far, this helper has only been tested for use with Debian and RedHat hosts.
 
+Full disclosure: changing the locale only uses global environment variables. Because the Beaker function I used is additive, it's only good for setting the locale to another language and then back to English **once**. At least that's all we've tested it with. Hopefully some day that will change. See the Development section.
+
 ## Development
 
 PRs welcome!
+
+### Testing
+
+#### Unit tests
+You can run unit tests with rspec
+```shell
+$ rspec spec/beaker/i18n_helper_spec.rb
+```
+
+#### Acceptance tests
+You can run acceptance tests with rspec, too, plus a little Beaker sugar:
+```shell
+$ BEAKER_provision=yes BEAKER_set=default rspec spec/acceptance
+```
 
 ## Contributing
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
         gem install openssl "~> 2.0.4" --no-rdoc --no-ri -- --with-openssl-dir=C:\msys64\mingw64
       }
       $host.SetShouldExit(0)
-  - bundle install --jobs 4 --retry 2 --without development
+  - bundle install --jobs 4 --retry 2
 
 before_test:
   - type Gemfile.lock
@@ -32,4 +32,4 @@ before_test:
   - bundle -v
 
 test_script:
-  - bundle exec rake
+  - bundle exec rspec spec/beaker

--- a/spec/acceptance/beaker/i18n_helper_spec.rb
+++ b/spec/acceptance/beaker/i18n_helper_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper_acceptance'
+
+describe Beaker::I18nHelper do
+  context 'japanese' do
+    describe '#install_language_pack_on' do
+      it 'installs a language pack' do
+        install_language_pack_on(hosts, 'ja_JP')
+        output = shell('localectl list-locales').stdout
+
+        expect(output).to match %r{ja_JP}
+      end
+
+      it 'changes the locale to japanese' do
+        change_locale_on(hosts, 'ja_JP.utf-8')
+        content = shell('locale').stdout
+
+        expect(content).to match(%r{ja_JP})
+        expect(content).to_not match(%r{en_US})
+      end
+
+      it 'changes the locale back to english' do
+        change_locale_on(hosts, 'en_US.utf-8')
+        content = shell('locale').stdout
+
+        expect(content).to match %r{en_US}
+      end
+
+      it 'errors given a bad lang string' do
+        expect { change_locale_on(hosts, 'jaJP') }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  ubuntu-1404-x64:
+    roles:
+      - agent
+      - default
+    platform: ubuntu-14.04-amd64
+    hypervisor: vagrant
+    box: puppetlabs/ubuntu-14.04-64-nocm
+CONFIG:
+  type: foss

--- a/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
+++ b/spec/acceptance/nodesets/docker/ubuntu-14.04.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  ubuntu-1404-x64:
+    platform: ubuntu-14.04-amd64
+    hypervisor: docker
+    image: ubuntu:14.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      # ensure that upstart is booting correctly in the container
+      - 'rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget && locale-gen en_US.UTF-8'
+CONFIG:
+  trace_limit: 200

--- a/spec/beaker/i18n_helper_spec.rb
+++ b/spec/beaker/i18n_helper_spec.rb
@@ -1,7 +1,39 @@
 require 'spec_helper'
 
-RSpec.describe Beaker::I18nHelper do
+RSpec.describe Beaker::I18nHelper do # rubocop:disable Metrics/BlockLength
   it 'has a version number' do
     expect(Beaker::I18nHelper::VERSION).not_to be nil
+  end
+  describe '#validate_lang_string' do
+    context 'with invalid args' do
+      ['jaJP', 'ja_JP-utf8', 'foo', '123'].each do |lang|
+        it_behaves_like 'an invalid lang string', lang
+      end
+    end
+    context 'with valid args' do
+      ['ja_JP', 'ja-JP', 'ja_JP.utf-8', 'ja-JP.UTF-8'].each do |lang|
+        it_behaves_like 'a valid lang string', lang
+      end
+    end
+  end
+  describe '#parse_lang' do
+    context 'underscored locale string' do
+      let(:val) { parse_lang('ja_JP.utf8') }
+      it 'returns an array' do
+        expect(val).to be_kind_of(Array)
+      end
+      it 'returns correct information' do
+        expect(val).to eq(%w[ja JP])
+      end
+    end
+    context 'hyphenated locale string' do
+      let(:val) { parse_lang('ja-JP.utf8') }
+      it 'returns an array' do
+        expect(val).to be_kind_of(Array)
+      end
+      it 'returns correct information' do
+        expect(val).to eq(%w[ja JP])
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,17 @@
 require 'bundler/setup'
 require 'beaker/i18n_helper'
+require 'rspec'
+
+RSpec.shared_examples 'a valid lang string' do |param|
+  it "#{param} should be valid" do
+    expect(Beaker::I18nHelper.valid_lang_string?(param)).to be true
+  end
+end
+RSpec.shared_examples 'an invalid lang string' do |param|
+  it "#{param} should be invalid" do
+    expect { Beaker::I18nHelper.valid_lang_string?(param) }.to raise_error(RuntimeError)
+  end
+end
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,3 @@
+require 'beaker'
+require 'beaker-rspec'
+require 'beaker/i18n_helper'


### PR DESCRIPTION
There's a lot in here.
- moves some logic around and creates two new methods, `parse_lang` and
  `valid_lang_string?`
- adds unit tests for these new methods
- adds acceptance tests for `install_language_pack_on` and
  `change_host_on`
- changes `change_host_on` to only assign values to env vars, not use
  localectl. it uses a beaker method called `add_env_vars` to accomplish
this.
- updates readme with changes as well as adds a testing section
- adds acceptance tests to travis and updates test script command for travis and
  appveyor
- adjusts rubocop config for some reasonable leniency